### PR TITLE
chore(release): promote v3.2.1 to master

### DIFF
--- a/.agents/skills/project-pull-request/SKILL.md
+++ b/.agents/skills/project-pull-request/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: project-pull-request
+description: Use when creating, updating, or reviewing a telegram-webapp-auth GitHub Pull Request. Defines dev-targeted branch flow, maintenance-mode constraints, assignee defaults, Conventional-style titles, required PR template sections, test evidence, security notes, and post-create reporting rules.
+---
+
+# Project Pull Request
+
+Use this skill for `telegram-webapp-auth` Pull Request work. The repository's
+`.github/PULL_REQUEST_TEMPLATE.md` is the required PR body format; do not
+replace it with a second template.
+
+## Preconditions
+
+- Inspect `git status`, current branch, upstream tracking, and diff before
+  creating or updating a PR.
+- Use `dev` as the base branch unless the user explicitly gives another base.
+- For release promotion, use `master` as the base branch and `dev` as the head branch.
+- Do not open a PR from `dev`, `master`, or a release branch except for the explicit `dev` to `master` release promotion PR.
+- This project is in maintenance mode. Keep PRs focused on bug fixes,
+  dependency updates, CI fixes, documentation corrections, or security fixes.
+- Push the current feature branch to `origin` before creating the PR.
+- Create PRs ready for review by default. Use draft only when the user
+  explicitly asks for a draft PR.
+
+## Assignee
+
+- Assign the PR to the authenticated GitHub user by default. Resolve the login
+  with `gh api user --jq .login` or the equivalent GitHub connector identity.
+- For this repository, the expected default assignee is `swimmwatch` unless the
+  user explicitly requests another assignee.
+- If the assignee cannot be resolved or GitHub rejects it, report the blocker
+  and leave the PR otherwise complete.
+
+## Title
+
+- Use a concise Conventional-style title, such as
+  `fix: reject duplicate init data keys`, `docs: clarify third-party validation`,
+  or `ci: fix Telegram docs update workflow`.
+- Use imperative or present-tense wording after the conventional prefix.
+- Make the title describe the main user-visible or maintenance change, not a
+  test result or implementation detail.
+
+## Body
+
+Fill every section from `.github/PULL_REQUEST_TEMPLATE.md`:
+
+- `Description`: explain what changed and why in 2-4 concrete bullets or short
+  paragraphs.
+- `Related Issue`: link the open issue when one exists. If there is no issue,
+  state that clearly instead of leaving placeholder text.
+- `Motivation and Context`: describe the bug, CI failure, dependency need, or
+  documentation gap being addressed.
+- `How Has This Been Tested (if appropriate)?`: list exact commands and
+  outcomes. If relevant checks were skipped, state why.
+- `Screenshots (if appropriate)`: include only for rendered documentation or UI
+  changes; otherwise mark as not applicable.
+
+Do not leave HTML comments or placeholder text in the submitted PR body.
+
+## Test Evidence
+
+Choose evidence based on the change:
+
+- Auth/parser/model changes: run targeted `pytest`, then `make test` when
+  feasible.
+- Type or style changes: run `make lint` or the relevant `mypy`, `flake8`, and
+  `black --check` commands.
+- Documentation changes: run `poetry run mkdocs build` or `make mkdocs-serve`
+  when visual review is needed.
+- Dependency changes: run `poetry update <package>` or `poetry update`, then
+  report the package changes and any tests run.
+- Workflow changes: run `make actionlint` if Docker is available, or state why
+  local action linting was not run.
+
+## Security Notes
+
+Call out security-sensitive areas explicitly when relevant:
+
+- Telegram init data parsing, HMAC validation, Ed25519 validation, expiry
+  checks, and unknown-field handling.
+- GitHub Actions permissions, `GITHUB_TOKEN`, `PYPI_TOKEN`, Codecov token, and
+  docs-update issue creation.
+- Runtime dependency changes, especially `cryptography`.
+
+## Create Or Update
+
+- Prefer the available GitHub app or connector. Use `gh` when connector support
+  is unavailable or insufficient.
+- If a PR already exists for the branch, update its title/body instead of
+  creating a duplicate.
+- After creating or updating the PR, report the PR URL, base/head branches,
+  title, assignee, whether it is draft or ready for review, and any skipped
+  checks.

--- a/.agents/skills/project-release/SKILL.md
+++ b/.agents/skills/project-release/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: project-release
+description: Use when preparing, publishing, verifying, or recovering a telegram-webapp-auth release. Requires a confirmed SemVer tag such as v3.1.1, guides Poetry version metadata, PR flow, GitHub Release creation, PyPI publishing, MkDocs deployment, and post-release verification.
+---
+
+# Project Release
+
+Use this skill only for `telegram-webapp-auth` release work. Require a
+confirmed target version such as `v3.1.1`, and decide whether it is stable or
+prerelease before preparing, publishing, or recovering a release. If the user
+has not provided a target version, propose one from changes since the previous
+release and ask the user to confirm it or choose a different tag before release
+execution.
+
+Release tags use Semantic Versioning 2.0.0 with the repository's `v` prefix,
+for example `v3.1.1` or `v3.2.0-rc.1`. The pinned specification URL is
+`https://semver.org/spec/v2.0.0.html`.
+
+## Choosing The Target Version
+
+- If the user provides a target tag, validate it before changing files.
+- If no target tag is provided, fetch tags and inspect changes since the
+  previous release tag:
+
+```bash
+git fetch origin --tags --prune
+git describe --tags --abbrev=0
+git log --oneline <previous-tag>..HEAD
+```
+
+- Inspect merged PR titles, dependency updates, CI changes, docs changes, and
+  public API changes.
+- Propose the next tag using Semantic Versioning 2.0.0:
+  - `MAJOR` for backward-incompatible public API, exception, data model, or
+    validation behavior changes;
+  - `MINOR` for backward-compatible public API additions;
+  - `PATCH` for backward-compatible fixes, dependency updates, docs, CI, or
+    packaging-only changes.
+- Present the proposed tag and short rationale, then ask the user to confirm it
+  or choose another tag. Do not edit version metadata until the tag is
+  confirmed.
+
+## Preconditions
+
+- Start from a clean worktree; do not overwrite unrelated user changes.
+- Fetch latest refs and branch from current `dev` unless the user explicitly
+  gives another base.
+- Confirm no existing Git tag or GitHub Release already uses the target version.
+- Before confirming the release tag, open and scan
+  `https://semver.org/spec/v2.0.0.html`, then validate that the requested tag
+  is the `v`-prefixed form of a SemVer 2.0.0 version.
+- Before committing, open and scan
+  `https://www.conventionalcommits.org/en/v1.0.0/`.
+
+## Version Preparation
+
+Update version metadata for the exact target version without the `v` prefix:
+
+- `pyproject.toml` `[project].version`
+- package metadata references in documentation only when they intentionally
+  show the current release version
+
+Then refresh lock metadata if Poetry reports it is needed:
+
+```bash
+poetry lock
+```
+
+Do not bump the package version outside release preparation.
+
+## Validation
+
+Before opening or merging the release PR, run the relevant local checks:
+
+```bash
+poetry install --no-root
+make lint
+make test
+poetry build
+poetry run mkdocs build
+```
+
+For workflow changes, also run:
+
+```bash
+make actionlint
+```
+
+If a check fails, fix the smallest release-relevant cause and rerun the
+relevant command. If a check cannot be run locally, record the reason in the PR
+body and final status.
+
+## PR And Release Flow
+
+- Commit release preparation as `chore(release): prepare vX.Y.Z`.
+- For release PR creation or updates, also read and follow
+  `.agents/skills/project-pull-request/SKILL.md`.
+- Open the release preparation PR to `dev`.
+- Include validation commands and outcomes in the PR body.
+- Call out security-sensitive release workflow changes, especially `PYPI_TOKEN`,
+  GitHub Release permissions, package publishing, and docs deployment.
+- Wait for required PR checks to pass before merging the release preparation PR.
+- After `dev` contains the release preparation commit, open a promotion PR from
+  `dev` to `master`.
+- Wait for required checks on the `dev` to `master` promotion PR before merging it.
+- Create the GitHub Release only after the release commit is on `master`.
+- Create a GitHub Release with:
+  - tag `vX.Y.Z`;
+  - target `master`, `origin/master`, or the exact `master` merge commit SHA;
+  - title `vX.Y.Z`;
+  - notes summarizing user-visible fixes, dependency updates, docs, and any
+    security-relevant changes.
+- Mark prerelease versions as GitHub prereleases.
+
+Do not create a GitHub Release from a commit that exists only on `dev`; the
+release tag must be reachable from `master`.
+
+Creating a GitHub Release triggers:
+
+- `.github/workflows/release.yml`, which builds and publishes the package to
+  PyPI with Poetry and `PYPI_TOKEN`;
+- `.github/workflows/docs.yml`, which rebuilds coverage docs and deploys MkDocs
+  to GitHub Pages.
+
+## Post-Release Verification
+
+Watch the release and docs workflows until they complete. Then verify:
+
+```bash
+python3 -m pip index versions telegram-webapp-auth
+python3 -m pip download --no-deps telegram-webapp-auth==X.Y.Z -d /tmp/telegram-webapp-auth-release-check
+```
+
+Also confirm:
+
+- GitHub Release exists with the expected tag and target.
+- The release tag is reachable from `origin/master`.
+- The release tag tree matches `origin/master` unless a later non-release
+  commit intentionally changed `master`.
+- PyPI shows `telegram-webapp-auth` version `X.Y.Z`.
+- Published metadata still advertises Python `>=3.10,<4.0`.
+- Documentation at `https://swimmwatch.github.io/telegram-webapp-auth/` renders
+  correctly after the docs workflow completes.
+
+## Recovery
+
+- If PyPI publishing fails because `PYPI_TOKEN` is missing or invalid, update
+  the secret and rerun the failed release job.
+- If a release artifact is already published to PyPI, do not delete and reuse
+  the same version for code defects. Prepare a follow-up patch release.
+- Rerun failed jobs only after confirming the failure is transient or caused by
+  fixed external configuration.
+- Keep release recovery notes in the final status report, including GitHub
+  Release, PyPI, and docs deployment state.

--- a/docs/guide/install.md
+++ b/docs/guide/install.md
@@ -2,6 +2,10 @@
 
 `telegram-webapp-auth` supports Python 3.10 and newer. It has one runtime dependency: `cryptography`, which is used for Telegram's Ed25519 third-party validation flow.
 
+!!! success "Current release"
+
+    Install `telegram-webapp-auth` `3.2.1` for the latest published package and documentation.
+
 ## :material-list-status: Requirements
 
 - Python 3.10+

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,10 @@ Validate Telegram Mini App `initData` in Python with a small, typed, security-fo
 
 `telegram-webapp-auth` implements the validation algorithms from the official Telegram Mini Apps documentation and returns structured dataclasses for users, chats, and init data.
 
+!!! success "Current release: 3.2.1"
+
+    The published package, documentation, and `master` branch are aligned for release `3.2.1`.
+
 <div class="grid cards" markdown>
 
 -   :material-shield-check: **Bot-token validation**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ poetry-plugin-export = ">=1.10.0"
 
 [project]
 name = "telegram-webapp-auth"
-version = "3.2.0"
+version = "3.2.1"
 description = "Python package that implements Telegram Mini Apps authentication algorithms."
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
THIS PROJECT IS IN MAINTENANCE MODE. We accept pull requests for bug fixes **only**. New features are not accepted.

## Description
Promote `dev` to `master` for release `3.2.1`.

This includes the release prep from PR #336:
- package version `3.2.1`
- explicit visible documentation markers for `3.2.1`
- project-local PR and release workflow skills updated to enforce `dev` -> `master` promotion before publishing releases

## Related Issue
N/A

## Motivation and Context
Release artifacts must be created from `master`, not from an unpromoted development branch. This PR aligns `master` with the validated `dev` release state before publishing `v3.2.1`.

## How Has This Been Tested (if appropriate)?
Validated on PR #336 before merge to `dev`:
- `make lint`
- `make test`
- `poetry build`
- `poetry run mkdocs build`
- actionlint
- `check-telegram-docs-updates`
- full Python/Poetry CI matrix
- Snyk and Codecov checks

## Screenshots (if appropriate):
N/A
